### PR TITLE
Change links to api to route to deployed url

### DIFF
--- a/cypress/e2e/main-spec.cy.js
+++ b/cypress/e2e/main-spec.cy.js
@@ -1,7 +1,7 @@
 describe('Main Page', () => {
     beforeEach(() => {
         cy.visit('http://localhost:3000/');
-        cy.intercept('GET', 'http://localhost:3001/api/v1/cliffs', { fixture: 'cliffs.json' }).as('cliffs')
+        cy.intercept('GET', 'https://cliff-jump-api.herokuapp.com/api/v1/cliffs', { fixture: 'cliffs.json' }).as('cliffs')
     })
 
     it('Should load main URL', () => {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -22,7 +22,7 @@ const App = () => {
       redirect: 'follow'
     };
 
-    fetch("http://localhost:8080/api/v1/cliffs", requestOptions)
+    fetch("https://cliff-jump-api.herokuapp.com/api/v1/cliffs", requestOptions)
       .then(response => response.json())
       .then(result => setData(result.cliffs))
       .catch(error => console.log(error, 'error'))


### PR DESCRIPTION
# Description

Changes URL routes to direct to api deployed on heroku

Fixes #14 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Going to the deployed link